### PR TITLE
Fix missing module error by installing deep_translator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ PySide6
 Unidecode
 dpath
 googletrans
+deep_translator


### PR DESCRIPTION
Here's the full error message without deep_translator being installed:

  (scrapy_env) > $ python /opt/homebrew/bin/scrapy crawl Vixen
  Traceback (most recent call last):
    File "/opt/homebrew/bin/scrapy", line 8, in <module>
      sys.exit(execute())
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/cmdline.py", line 157, in execute
      cmd.crawler_process = CrawlerProcess(settings)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/crawler.py", line 318, in __init__
      super().__init__(settings)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/crawler.py", line 190, in __init__
      self.spider_loader = self._get_spider_loader(settings)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/crawler.py", line 184, in _get_spider_loader
      return loader_cls.from_settings(settings.frozencopy())
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/spiderloader.py", line 69, in from_settings
      return cls(settings)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/spiderloader.py", line 24, in __init__
      self._load_all_spiders()
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/spiderloader.py", line 53, in _load_all_spiders
      for module in walk_modules(name):
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/utils/misc.py", line 85, in walk_modules
      mods += walk_modules(fullpath)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/site-packages/scrapy/utils/misc.py", line 87, in walk_modules
      submod = import_module(fullpath)
    File "/opt/homebrew/Caskroom/miniconda/base/envs/scrapy_env/lib/python3.10/importlib/__init__.py", line 126, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 883, in exec_module
    File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
    File "/Users/MidnightRider/Documents/GitHub/scrapy/tpdb/spiders/scenes/siteModelMediaTW.py", line 5, in <module>
      from deep_translator import GoogleTranslator
  ModuleNotFoundError: No module named 'deep_translator'