### PR TITLE
Fix scraping issue with item['back'] = None

### DIFF
--- a/tpdb/pipelines.py
+++ b/tpdb/pipelines.py
@@ -108,7 +108,7 @@ class TpdbApiScenePipeline:
         item['description'] = html.unescape(item['description'])
 
         payload = {
-            'back': BaseScraper.prepare_url(item['back']),
+            'back': BaseScraper.prepare_url(item['back'] or ''),
             'back_blob': item['back_blob'],
             'date': item['date'],
             'description': item['description'],


### PR DESCRIPTION
In some circumstances None is put into item['back']. This causes an inssue later on when item['back'] is used and attempted to be unquoted. To fix this, if item['back'] = None, use empty string instead when prepping a url.