### PR TITLE
Fix Submodule Sync Workflow

### DIFF
--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           submodules: 'recursive'
 
       - uses: actions/setup-python@v3


### PR DESCRIPTION
By default, the action will only fetch the latest commit (depth=1). This prevents the submodule update from working as expected.

Fixes: #122